### PR TITLE
Zusätzliche Voraussetzung, um die Vervollständigung topologisieren zu können

### DIFF
--- a/vervollstaendigungen1.tex
+++ b/vervollstaendigungen1.tex
@@ -96,6 +96,8 @@
 		Umgebung \(U\) von \(0\) gilt, daß \(U_n \subset U\) für \(n \gg 0\).
 		\\
 		Eine solche Folge heißt \emph{Umgebungsbasis von \(0\)}.
+		\\
+		Wir setzen ferner voraus, daß die $U_i$ als Normalteiler gewählt werden können.
 	\end{visibleenv}
 	\begin{definition}<+->
 		Sei \(G\) eine topologische Gruppe. Eine \emph{Cauchy-Folge \((g_n)_{n \in \set N_0}\) in \(G\)}


### PR DESCRIPTION
@timjb ist aufgefallen, dass die Setzung der Topologie auf der Vervollständigung `\hat G` nicht wohldefiniert ist. Genauer respektiert die Definition von `\hat U` nicht die Äquivalenzrelation.

Tim hat ein explizites Beispiel: `G = \mathbb{Q}`, `U = (-1, 1)`. Dann sind die Cauchyfolgen `(1 - 1/2^n)_n` und `(1 + (-1/2^n))_n` äquivalent, aber die erste ist schließlich in `U` und die zweite nicht.

Eine einfache Möglichkeit, den Abschnitt zu korrigieren, besteht darin, über _lineare_ topologische Gruppen zu sprechen (wobei wir diesen Begriff nicht unbedingt einführen müssen), wie es Daniel Murfet in http://therisingsea.org/notes/Section2.9-FormalSchemes.pdf#page=2 macht.
