### PR TITLE
Tippfehler verbessert

### DIFF
--- a/bewertungsringe.tex
+++ b/bewertungsringe.tex
@@ -89,7 +89,7 @@
 			Da \(\psi(B) \cong B/\ker \psi\) als Unterring der Körpers \(L\) ein
 			Integritätsbereich ist, ist \(\ker \psi\) ein Primideal.
 		\item
-			Nach der universellen Eigenschaft der Lokalisierung, faktorisiert
+			Nach der universellen Eigenschaft der Lokalisierung faktorisiert
 			\(\psi\) über einen Homomorphismus \(\psi_{\ideal m}\colon
 			B_{\ideal m} \to L\).
 		\item
@@ -189,7 +189,7 @@
 		\item
 			Sei umgekehrt \(x \notin \bar A\). Dann ist \(x \notin A' \coloneqq
 			A[x^{-1}] \subset K\). Damit ist \(x^{-1}\) keine Einheit in \(A'\),
-			also in einem maximalen Ideal \(\ideal m\) von \(A'\) enthalten.
+			also in einem maximalen Ideal \(\ideal m'\) von \(A'\) enthalten.
 		\item
 			Sei \(L\) ein algebraischer Abschluß des Körpers \(k' \coloneqq
 			A'/\ideal m'\). Der Homomorphismus
@@ -208,7 +208,7 @@
 		ein \(u \in A \setminus \{0\}\) mit folgender Eigenschaft: Jeder
 		Homomorphismus \(\phi\colon A \to L\) in einen algebraisch
 		abgeschlossenen Körper mit \(\phi(u) \neq 0\) kann zu einem
-		Homomorphismus \(\psi\colon B \to L\) mit \(\phi(v) \neq 0\)
+		Homomorphismus \(\psi\colon B \to L\) mit \(\psi(v) \neq 0\)
 		fortgesetzt werden.
 	\end{proposition}
 	\begin{proof}<+->

--- a/erweiterungen.tex
+++ b/erweiterungen.tex
@@ -80,7 +80,7 @@
 		\begin{enumerate}[<+->]
 		\item
 			Ist \(p = 2\), ist \(\set Z[\iu](p) = (1 + \iu)(1 + \iu)\), das Quadrat eines
-			Primideals in \(\set Z\).
+			Primideals in \(\set Z[\iu]\).
 		\item
 			Ist \(p = 1\) modulo \(4\), ist \(\set Z[\iu](p)\) das Produkt zweier
 			verschiedener Primideale, also etwa \(\set Z[\iu](5) = (2 + \iu)(2 - \iu)\).

--- a/ideallokalisierungen.tex
+++ b/ideallokalisierungen.tex
@@ -182,7 +182,7 @@
 
 \begin{frame}{Lokalisierungen und Quotienten}
 	\begin{corollary}<+->
-		Sei \(A\) ein kommutativer Ring. Seien \(N, P\) zwei \(A\)-Moduln. Sei \(S \subset A\) multiplikativ abgeschlossen.
+		Sei \(A\) ein kommutativer Ring. Seien \(N, P\) zwei Untermoduln eines \(A\)-Moduls \(M\). Sei \(S \subset A\) multiplikativ abgeschlossen.
 		Ist \(P\) endlich erzeugt, so gilt \(S^{-1} (N : P) = (S^{-1} N : S^{-1} P)\).
 	\end{corollary}
 	\begin{proof}<+->

--- a/noethersche.tex
+++ b/noethersche.tex
@@ -150,7 +150,7 @@
 			in \(B_0\) ist, und damit ist \(C\) eine endliche \(B_0\)-Algebra.
 		\item
 			Da \(B_0\) noethersch ist, ist damit \(C\) ein noetherscher \(B_0\)-Modul.
-			Da \(B\) Untermodul von	\(C\), ist \(B\) als \(B_0\)-Modul endlich erzeugt.
+			Da \(B\) ein Untermodul von \(C\) ist, ist \(B\) als \(B_0\)-Modul endlich erzeugt.
 		\item
 			Schließlich ist \(B_0\) als \(A\)-Algebra endlich erzeugt, also ist
 			auch \(B\) als \(A\)-Algebra endlich erzeugt.

--- a/operationen.tex
+++ b/operationen.tex
@@ -177,7 +177,7 @@
         Ring \(A\). Dann ist \(\phi\colon A \to \prod\limits_{i = 1}^n
         A/\ideal a_i, x \mapsto (x + \ideal a_1, \dotsc, x + \ideal a_n)\)
         genau dann surjektiv, wenn die Ideale \(\ideal a_i\) paarweise
-        teilerfremd sind.
+        koprim sind.
     \end{proposition}
     \begin{proof}<+->
         \begin{enumerate}[<+->]
@@ -187,7 +187,7 @@
             mit \(\phi(x) = (1, 0, \dotsc, 0)\). Es folgt, daß \(1 = (1 - x) + x
             \in \ideal a_1 + \ideal a_2\).
         \item
-            Seien umgekehrt die \(\ideal a_i\) paarweise teilerfremd. Wir
+            Seien umgekehrt die \(\ideal a_i\) paarweise koprim. Wir
             zeigen, daß ein \(x \in A\) mit \(\phi(x) = (1, 0, \dotsc, 0)\)
             existiert. Da \(\ideal a_1\) und \(\ideal a_i\) für \(i > 1\) koprim
             sind, existieren \(u_i \in \ideal a_1\) und \(v_i \in \ideal a_i\)

--- a/seidenberg2.tex
+++ b/seidenberg2.tex
@@ -62,7 +62,7 @@
 	\end{proposition}
 	\begin{proof}<+->
 		Seien \(K\) der Quotientenkörper von \(A\) und \(C\) der ganze Abschluß
-		von \(A\) in \(K\). Dann ist \(A\) genau dann ganz abgeschloseen,
+		von \(A\) in \(K\). Dann ist \(A\) genau dann ganz abgeschlossen,
 		wenn \(\phi\colon A \to C, x \mapsto x\) surjektiv ist. Es ist
 		Surjektivität eine lokale Eigenschaft und Bilden des ganzen Abschlusses
 		mit Lokalisierung verträglich.

--- a/vervollstaendigungen2.tex
+++ b/vervollstaendigungen2.tex
@@ -227,7 +227,7 @@
 		auf der additiven Gruppe von \(M\), so daß \(M \supset \ideal a M \supset \ideal a^2 M \supset \dotsb\) zu einer
 		Umgebungsbasis von \(0\) wird, die \emph{\(\ideal a\)-adische Topologie}.
 		\\
-		In der Tat wird \(M\) damit zu einem topologischen \(A\)-Modul, wenn \(M\) mit der \(\ideal a\)-adischen Topologie
+		In der Tat wird \(M\) damit zu einem topologischen \(A\)-Modul, wenn \(A\) mit der \(\ideal a\)-adischen Topologie
 		versehen wird.
 	\end{example}
 	\begin{visibleenv}<+->
@@ -250,7 +250,7 @@
 	Damit definiert \(\phi\) eine Abbildung \(\hat\phi = \hat\phi_{\ideal a}\colon \hat M_{\ideal a} \to \hat N_{\ideal a}\).
 	\begin{proposition}<+->
 		Die Abbildung \(\hat\phi_{\ideal a}\colon \hat M_{\ideal a} \to \hat N_{\ideal a}\) ist ein stetiger
-		Homomorphismus topologischer Ringe.
+		Homomorphismus topologischer \(\hat A_{\ideal a}\)-Moduln.
 		\qed
 	\end{proposition}
 \end{frame}


### PR DESCRIPTION
Außerdem ist mir aufgefallen: In den Hilfssätzen 28.6 und 28.7 wird die Voraussetzung, dass L algebraisch abgeschlossen ist, nicht gebraucht.
