### PR TITLE
Typo korrigiert.

### DIFF
--- a/noethersche.tex
+++ b/noethersche.tex
@@ -78,8 +78,8 @@
 	\begin{proof}<+->
 		\begin{enumerate}[<+->]
 		\item<.->
-			Sei \(\ideal a\) ein Ideal in \(A[x]\). Die führenden Koeffizienten der
-			Polynome in \(\ideal a\) erzeugen ein Ideal \(\ideal l\) in \(A\), welches
+			Sei \(\ideal a\) ein Ideal in \(A[x]\). Die Menge der führenden Koeffizienten der
+			Polynome in \(\ideal a\) ist ein Ideal \(\ideal l\) in \(A\), welches
 			nach Voraussetzung von endlich vielen Elementen \(a_1, \dotsc, a_n\) erzeugt ist.
 		\item
 			Zu jedem \(a_i\) wählen wir ein Polynom \(f_i \in \ideal a\) mit Leitmonom


### PR DESCRIPTION
Der zweite Beweisschritt ist so formuliert, dass man denkt, dass es trivial
ist, zu jedem a_i ein passendes Polynom f_i zu wählen. Damit das wirklich
trivial ist, sollte man sich aber schon nach Schritt 1 bewusst sein, dass die
Leitkoeffizienten selbst schon ein Ideal bilden, und nicht erst durch
Hinzunahme von Linearkombinationen zu einem Ideal ergänzt werden müssen.